### PR TITLE
added the `include <cstddef>` statement to resolve a build issue in computation

### DIFF
--- a/include/geos/io/WKBWriter.h
+++ b/include/geos/io/WKBWriter.h
@@ -24,6 +24,7 @@
 
 #include <geos/util/Machine.h> // for getMachineByteOrder
 #include <iosfwd>
+#include <cstddef>
 
 // Forward declarations
 namespace geos {


### PR DESCRIPTION
This PR addresses a build issue encountered in the computation repository. The issue was resolved by adding the `#include <cstddef>` statement to the appropriate file. 